### PR TITLE
Enable API key storage in Streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,17 @@ The results from both configurations are analyzed to measure agreement rates and
 
 - Python 3.8+
 - Required Python packages (install with `pip install -r requirements.txt`)
-- API keys for OpenAI and Anthropic (Claude) in a `.env` file
+- API keys for OpenAI and Anthropic (Claude) in a `.env` file. A DeepSeek key is optional.
+
+### Streamlit Interface
+
+You can interact with the framework using a simple Streamlit web app:
+
+```bash
+streamlit run app.py
+```
+
+Use the **API Keys** page in the sidebar to enter your credentials. The keys are saved to a `.env` file so they persist between sessions.
 
 ### Validation Process
 

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import shutil
 from pathlib import Path
 import base64
 import tempfile
+from dotenv import load_dotenv
 
 # Define paths
 CHECKLISTS_PATH = os.path.join("data", "Guidelines")  # Keeping the folder name for backward compatibility, but using "checklist" in UI
@@ -127,18 +128,73 @@ def display_json(file_path):
 # Main app
 def main():
     st.set_page_config(page_title="RWE LLM Validator", page_icon="📊", layout="wide")
-    
+
     st.title("RWE LLM Validator")
     st.markdown("A tool for validating research papers against reporting guidelines using Large Language Models (LLMs).")
-    
+
+    # Load existing API keys so they are available to the app
+    load_dotenv()
+
     # Ensure directories exist
     ensure_directories()
-    
+
     # Sidebar
     st.sidebar.title("Navigation")
-    page = st.sidebar.radio("Go to", ["Upload Checklists", "Upload Papers", "Run Validation", "View Results"])
+    page = st.sidebar.radio(
+        "Go to",
+        [
+            "API Keys",
+            "Upload Checklists",
+            "Upload Papers",
+            "Run Validation",
+            "View Results",
+        ],
+    )
     
-    if page == "Upload Checklists":
+    if page == "API Keys":
+        st.header("API Keys")
+
+        # Existing values from environment if present
+        openai_key = st.text_input(
+            "OpenAI API Key",
+            value=os.environ.get("OPENAI_API_KEY", ""),
+            type="password",
+        )
+        anthropic_key = st.text_input(
+            "Anthropic API Key",
+            value=os.environ.get("ANTHROPIC_API_KEY", ""),
+            type="password",
+        )
+        deepseek_key = st.text_input(
+            "DeepSeek API Key",
+            value=os.environ.get("DEEPSEEK_API_KEY", ""),
+            type="password",
+        )
+
+        if st.button("Save API Keys"):
+            env_path = Path(".env")
+            current = {}
+            if env_path.exists():
+                with open(env_path, "r") as f:
+                    for line in f:
+                        if "=" in line:
+                            k, v = line.strip().split("=", 1)
+                            current[k] = v
+            if openai_key:
+                current["OPENAI_API_KEY"] = openai_key
+            if anthropic_key:
+                current["ANTHROPIC_API_KEY"] = anthropic_key
+            if deepseek_key:
+                current["DEEPSEEK_API_KEY"] = deepseek_key
+
+            with open(env_path, "w") as f:
+                for k, v in current.items():
+                    f.write(f"{k}={v}\n")
+
+            load_dotenv(override=True)
+            st.success("API keys saved and loaded.")
+
+    elif page == "Upload Checklists":
         st.header("Upload Checklists")
         
         # Create new checklist folder

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ numpy>=1.24.3
 pandas>=2.0.3
 scikit-learn>=1.3.2
 loguru>=0.7.2
+streamlit>=1.30
 
 # PDF Processing
 PyPDF2>=3.0.1


### PR DESCRIPTION
## Summary
- add API key upload page in the Streamlit UI
- document the Streamlit interface in the README
- include Streamlit dependency

## Testing
- `python -m pytest -k nothing -q` *(fails: No module named pytest)*